### PR TITLE
fix request loading

### DIFF
--- a/packages/noahv-request/lib/index.js
+++ b/packages/noahv-request/lib/index.js
@@ -129,7 +129,7 @@ function handlerGlobalLoadingFormRequest(config) {
     else if (config.showLoading !== false) {
         const DefaultLoading = {
             size: 40,
-            type: 'load-c',
+            type: 'ios-loading',
             class: 'noahv-loading',
             text: 'Loading...'
         };


### PR DESCRIPTION
The old noahrequestloading cannot be displayed any more, and the new icon will be replaced.