### PR TITLE
fix #62

### DIFF
--- a/template/common-ts/scripts/webpack.base.conf.js
+++ b/template/common-ts/scripts/webpack.base.conf.js
@@ -71,7 +71,9 @@ module.exports = {
                     cacheDirectory: true
                 }
             }],
-            include: /(src|node_modules\/noahv?)/
+            include: function (filePath) {
+                return new RegExp(projectRoot + "/(src|node_modules\/noahv?)/").test(filePath);
+            }
         },
         {
             test: /\.css$/,

--- a/template/common/scripts/webpack.base.conf.js
+++ b/template/common/scripts/webpack.base.conf.js
@@ -62,7 +62,9 @@ module.exports = {
                     cacheDirectory: true
                 }
             }],
-            include: /(src|node_modules\/noahv?)/
+            include: function (filePath) {
+                return new RegExp(projectRoot + "/(src|node_modules\/noahv?)/").test(filePath);
+            }
         },
         {
             test: /\.css$/,

--- a/template/dashboard/scripts/webpack.base.conf.js
+++ b/template/dashboard/scripts/webpack.base.conf.js
@@ -60,7 +60,9 @@ module.exports = {
                     cacheDirectory: true
                 }
             }],
-            include: /(src|node_modules\/noahv?)/
+            include: function (filePath) {
+                return new RegExp(projectRoot + "/(src|node_modules\/noahv?)/").test(filePath);
+            }
         },
         {
             test: /\.css$/,


### PR DESCRIPTION
changelog:
1.  use `RegExp(projectRoot + "/(src|node_modules\/noahv?)/")`  to avoid include other files.